### PR TITLE
Hunspell: fix Windows compatibility

### DIFF
--- a/src/Hunspell/Hunspell.php
+++ b/src/Hunspell/Hunspell.php
@@ -86,11 +86,12 @@ class Hunspell extends Ispell
             $languages = [];
 
             $output = explode(PHP_EOL, $process->getErrorOutput());
+            $is_win = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
             foreach ($output as $line) {
                 $line = trim($line);
                 if ('' === $line // Skip empty lines
                     || substr($line, -1) === ':' // Skip headers
-                    || strpos($line, ':') !== false // Skip search path
+                    || strpos($line, $is_win ? ';' : ':') !== false // Skip search path
                 ) {
                     continue;
                 }


### PR DESCRIPTION
On Windows, all paths contain a colon (`:`) and search paths are separated by a semicolon (`;`).

Fixes #10.