### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5",
         "php-coveralls/php-coveralls": "^2.0",
-        "satooshi/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/tests/Unit/Source/FileSourceTest.php
+++ b/tests/Unit/Source/FileSourceTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Mekras\Speller\Tests\Unit\Source;
 
 use Mekras\Speller\Source\FileSource;
+use Mekras\Speller\Exception\SourceException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,12 +47,16 @@ class FileSourceTest extends TestCase
 
     /**
      * getAsString should throw SourceException if file not exists.
-     *
-     * @expectedException \Mekras\Speller\Exception\SourceException
      */
     public function testFileNotExists(): void
     {
-        $source = new FileSource('non-existent.file');
+        $noExistedFilePath = 'non-existent.file';
+
+        $source = new FileSource($noExistedFilePath);
+
+        $this->expectException(SourceException::class);
+        $this->expectExceptionMessage(sprintf('File "%s" not exists', $noExistedFilePath));
+
         $source->getAsString();
     }
 }

--- a/tests/Unit/Source/HtmlSourceTest.php
+++ b/tests/Unit/Source/HtmlSourceTest.php
@@ -13,6 +13,7 @@ namespace Mekras\Speller\Tests\Unit\Source;
 
 use Mekras\Speller\Source\HtmlSource;
 use Mekras\Speller\Source\StringSource;
+use Mekras\Speller\Exception\SourceException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,12 +45,12 @@ class HtmlSourceTest extends TestCase
 
     /**
      * HtmlSource should throw SourceException on invalid HTML.
-     *
-     * @expectedException \Mekras\Speller\Exception\SourceException
-     * @expectedExceptionMessage Opening and ending tag mismatch: a and b at 1:11
      */
     public function testInvalidHtml(): void
     {
+        $this->expectException(SourceException::class);
+        $this->expectExceptionMessage('Opening and ending tag mismatch: a and b at 1:11');
+
         new HtmlSource(new StringSource('<a><b></a></b>'));
     }
 }


### PR DESCRIPTION
# Changed log
- Remove duplicate and abandoned `php-coveralls` package.
- The `@expectedException` comment annotation will be deprecated in the future of stable PHPUnit version.
Using the `expectException` method instead.