### PR TITLE
Fix PHP error triggered by malformed HTML attributes

### DIFF
--- a/src/Source/Filter/HtmlFilter.php
+++ b/src/Source/Filter/HtmlFilter.php
@@ -152,14 +152,18 @@ class HtmlFilter implements Filter
                     switch (true) {
                         case self::CTX_ATTR_VALUE === $expecting:
                             $context = self::CTX_ATTR_VALUE;
-                            $ignoreAttrValue
-                                = !in_array(strtolower($attrName), self::$textAttrs, true);
+                            if ($attrName !== null) {
+                                $ignoreAttrValue = !in_array(strtolower($attrName), self::$textAttrs, true);
+                            }
                             $expecting = null;
                             $char = ' ';
                             break;
 
                         case self::CTX_ATTR_VALUE === $context:
                             $context = self::CTX_TAG_ATTRS;
+                            $char = ' ';
+                            break;
+                        default:
                             $char = ' ';
                             break;
                     }

--- a/tests/Unit/Source/Filter/HtmlFilterTest.php
+++ b/tests/Unit/Source/Filter/HtmlFilterTest.php
@@ -61,4 +61,32 @@ class HtmlFilterTest extends TestCase
         $text = "   Foo    \n                                      \n            ";
         static::assertEquals($text, $filter->filter($html));
     }
+
+    public function testMalformedAttribute(): void
+    {
+        $filter = new HtmlFilter();
+        $html = '<p ""="">test</p>';
+        $text = '         test    ';
+        static::assertEquals($text, $filter->filter($html));
+
+        $html = '<p "">test</p>';
+        $text = '      test    ';
+        static::assertEquals($text, $filter->filter($html));
+
+        $html = '<p ">test</p>';
+        $text = '     test    ';
+        static::assertEquals($text, $filter->filter($html));
+
+        $html = '<p name=">test</p>';
+        $text = '          test    ';
+        static::assertEquals($text, $filter->filter($html));
+
+        $html = '<p name"=">test</p>';
+        $text = '           test    ';
+        static::assertEquals($text, $filter->filter($html));
+
+        $html = '<p "name=">test</p>';
+        $text = '           test    ';
+        static::assertEquals($text, $filter->filter($html));
+    }
 }


### PR DESCRIPTION
This PR fixes a PHP error that can occur when there is a malformed attribute in the HTML source (for example `<p ""="">test</p>`).

The error is the following : 
```
Uncaught PHP Exception TypeError: "strtolower() expects parameter 1 to be string, null given" at vendor/mekras/php-speller/src/Source/Filter/HtmlFilter.php line 156
```

I was able to reproduce the error in the unit tests and fix it.

Thanks for this very useful library :)