### PR TITLE
Fix Aspell output parsing when the original words contains a colon

### DIFF
--- a/src/Ispell/Ispell.php
+++ b/src/Ispell/Ispell.php
@@ -183,15 +183,16 @@ class Ispell extends ExternalSpeller
                     $issues [] = $issue;
                     break;
                 case '&':
-                    $parts = explode(':', $line);
-                    $parts[0] = explode(' ', $parts[0]);
-                    $parts[1] = explode(', ', trim($parts[1]));
-                    $word = $parts[0][1];
-                    $issue = new Issue($word);
-                    $issue->line = $lineNo;
-                    $issue->offset = trim($parts[0][3]);
-                    $issue->suggestions = $parts[1];
-                    $issues [] = $issue;
+                    $matches = [];
+                    $pattern = '/^& (?<original>[^\s]+) \d+ (?<offset>\d+): (?<suggestions>.*)$/';
+                    if (1 === preg_match($pattern, $line, $matches)) {
+                        $word = $matches['original'];
+                        $issue = new Issue($word);
+                        $issue->line = $lineNo;
+                        $issue->offset = $matches['offset'];
+                        $issue->suggestions = explode(', ', $matches['suggestions']);
+                        $issues[] = $issue;
+                    }
                     break;
             }
         }

--- a/tests/Unit/Aspell/AspellTest.php
+++ b/tests/Unit/Aspell/AspellTest.php
@@ -69,7 +69,7 @@ class AspellTest extends TestCase
                 'ru',
                 'ru-ye',
                 'ru-yeyo',
-                'ru-yo'
+                'ru-yo',
             ],
             $aspell->getSupportedLanguages()
         );
@@ -114,5 +114,36 @@ class AspellTest extends TestCase
 
         static::assertEquals('CCould', $issues[4]->word);
         static::assertEquals(4, $issues[4]->line);
+    }
+
+    /**
+     * Test spell checking when a word contains a colon
+     *
+     * @see https://github.com/mekras/php-speller/issues/24
+     */
+    public function testCheckTestWithColon(): void
+    {
+        $source = $this->prophesize(EncodingAwareSource::class);
+        $source->getEncoding()->shouldBeCalled()->willReturn('UTF-8');
+        $source->getAsString()->shouldBeCalled()->willReturn('S:t Petersburg är i Ryssland');
+
+        $process = $this->prophesize(Process::class);
+
+        $process->setTimeout(600)->shouldBeCalled();
+        $process->setEnv([])->shouldBeCalled();
+        $process->setInput('S:t Petersburg är i Ryssland')->shouldBeCalled();
+        $process->run()->shouldBeCalled();
+        $process->getExitCode()->shouldBeCalled()->willReturn(0);
+        $process->getOutput()->shouldBeCalled()->willReturn(file_get_contents(__DIR__ . '/fixtures/check_sv.txt'));
+
+        $aspell = new Aspell();
+        $aspell->setProcess($process->reveal());
+        $issues = $aspell->checkText($source->reveal(), ['sv']);
+
+        static::assertCount(1, $issues);
+        static::assertEquals('S:t', $issues[0]->word);
+        static::assertEquals(1, $issues[0]->line);
+        static::assertEquals(0, $issues[0]->offset);
+        static::assertEquals(['St', 'Set', 'Sot', 'Söt', 'Stl', 'Stå'], $issues[0]->suggestions);
     }
 }

--- a/tests/Unit/Aspell/AspellTest.php
+++ b/tests/Unit/Aspell/AspellTest.php
@@ -14,6 +14,7 @@ namespace Mekras\Speller\Tests\Unit\Aspell;
 
 use Mekras\Speller\Aspell\Aspell;
 use Mekras\Speller\Source\EncodingAwareSource;
+use Mekras\Speller\Source\StringSource;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -121,14 +122,11 @@ class AspellTest extends TestCase
      *
      * @see https://github.com/mekras/php-speller/issues/24
      */
-    public function testCheckTestWithColon(): void
+    public function testCheckTextWithColon(): void
     {
-        $source = $this->prophesize(EncodingAwareSource::class);
-        $source->getEncoding()->shouldBeCalled()->willReturn('UTF-8');
-        $source->getAsString()->shouldBeCalled()->willReturn('S:t Petersburg är i Ryssland');
+        $source = new StringSource('S:t Petersburg är i Ryssland', 'UTF-8');
 
         $process = $this->prophesize(Process::class);
-
         $process->setTimeout(600)->shouldBeCalled();
         $process->setEnv([])->shouldBeCalled();
         $process->setInput('S:t Petersburg är i Ryssland')->shouldBeCalled();
@@ -138,12 +136,34 @@ class AspellTest extends TestCase
 
         $aspell = new Aspell();
         $aspell->setProcess($process->reveal());
-        $issues = $aspell->checkText($source->reveal(), ['sv']);
+        $issues = $aspell->checkText($source, ['sv']);
 
         static::assertCount(1, $issues);
         static::assertEquals('S:t', $issues[0]->word);
         static::assertEquals(1, $issues[0]->line);
         static::assertEquals(0, $issues[0]->offset);
         static::assertEquals(['St', 'Set', 'Sot', 'Söt', 'Stl', 'Stå'], $issues[0]->suggestions);
+    }
+
+    /**
+     * Test spell checking when aspell binary output is unexpected
+     */
+    public function testUnexpectedOutputParsing(): void
+    {
+        $source = new StringSource('The quick brown fox jumps over the lazy dog', 'UTF-8');
+
+        $process = $this->prophesize(Process::class);
+        $process->setTimeout(600)->shouldBeCalled();
+        $process->setEnv([])->shouldBeCalled();
+        $process->setInput('The quick brown fox jumps over the lazy dog')->shouldBeCalled();
+        $process->run()->shouldBeCalled();
+        $process->getExitCode()->shouldBeCalled()->willReturn(0);
+        $process->getOutput()->shouldBeCalled()->willReturn('& unexpected output: foo, bar, baz');
+
+        $aspell = new Aspell();
+        $aspell->setProcess($process->reveal());
+        $issues = $aspell->checkText($source, ['en']);
+
+        static::assertEmpty($issues);
     }
 }

--- a/tests/Unit/Aspell/fixtures/check_sv.txt
+++ b/tests/Unit/Aspell/fixtures/check_sv.txt
@@ -1,0 +1,6 @@
+@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.6.1)
+& S:t 23 0: St, Set, Sot, Söt, Stl, Stå
+? Petersburg 0 4: Peters
+*
+*
+*


### PR DESCRIPTION
Fixes #24 