### PR TITLE
Fix incorrect escaping of hunspell command

### DIFF
--- a/src/Hunspell/Hunspell.php
+++ b/src/Hunspell/Hunspell.php
@@ -158,7 +158,8 @@ class Hunspell extends Ispell
     {
         $args = [
             // Input encoding
-            '-i ' . ($source instanceof EncodingAwareSource ? $source->getEncoding() : 'UTF-8'),
+            '-i',
+            ($source instanceof EncodingAwareSource ? $source->getEncoding() : 'UTF-8'),
             '-a' // Machine readable output
         ];
 
@@ -167,7 +168,8 @@ class Hunspell extends Ispell
                 ->map($languages, $this->getSupportedLanguages());
             $dictionaries = array_merge($dictionaries, $this->customDictionaries);
             if (count($dictionaries)) {
-                $args[] = '-d ' . implode(',', $dictionaries);
+                $args[] = '-d';
+                $args[] = implode(',', $dictionaries);
             }
         }
 


### PR DESCRIPTION
Fix incorrect slashing of hunspell command params, which causes "Can't open affix or dictionary files for dictionary named "default"" on Alpine Docker container.

This example script
```php
$source = new StringSource('Tiger, tigr, burning bright');
$speller = new Hunspell();
$issues = $speller->checkText($source, ['en_US']);
```

was calling this command:
```bash
'hunspell' '-i UTF-8' '-a' '-d en_US'
```
***Which is not correctly parsed by hunspell on Alpine Docker container and throws error*** `Failed to execute "'hunspell' '-i UTF-8' '-a' '-d en_US'": Can't open affix or dictionary files for dictionary named "default".`

***Executing this command inside docker containter results same error.***


now it calls:
```bash
'hunspell' '-i' 'UTF-8' '-a' '-d' 'en_US'
```
which is successflully parsed by hunspel. Tested on Hunspell 1.7.0