### PR TITLE
Add support for php8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.4
       env:
         - PHPUNIT_FLAGS="--coverage-clover build/logs/clover.xml"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.4 - 2021-03-15
+### Changed
+- Add support for PHP 8
+### Removed
+- Removed `getMessage` from `PhpSpellerException` as it already declared from `Throwable`
+
 ## 2.1.3 - 2020-09-23
 ### Fixed
 - Fix incorrect escaping of hunspell command (#29)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1",
         "symfony/process": "^4.4 || ^5.0",
         "ext-iconv": "*",
         "ext-dom": "*",

--- a/src/Exception/PhpSpellerException.php
+++ b/src/Exception/PhpSpellerException.php
@@ -21,8 +21,4 @@ use Throwable;
  */
 interface PhpSpellerException extends Throwable
 {
-    /**
-     * @return string
-     */
-    public function getMessage();
 }


### PR DESCRIPTION
This will enable php-speller to be installed with php8.
Also change the build on travis to add coverage for 7.4 and a new step on php8.

Should resolve #31 